### PR TITLE
Doc generator for react-ui page

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ You can verify everything is working (alt tags correctly placed, no incorrect ur
 
 ## Automatic page generation with `./build-docs.sh`
 
-Fetches docs content from other sources (e.g. GitHub repositories) and transforms it to Speechly Docs pages. The page files are modified "in place", so you can check the diffs with `git status` and `git diff` before committing and pushing.
+Fetches docs content from other sources (e.g. GitHub repositories) and transforms it to Speechly Docs pages. The generated page files are put in their respective places in the Docs folder, so you can check the diffs with `git status` and `git diff` before committing and pushing.
+
+The source addresses and pages are defined in `build-docs.sh` file.
+
+If there is an error fetching the content (e.g. content is not available), an error will be displayed.
 
 ### Generated pages
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ You can verify everything is working (alt tags correctly placed, no incorrect ur
 
 ## Automatic page generation with `./build-docs.sh`
 
-Fetches data from other sources (e.g. GitHub repositories) and modifies the content for Docs. The pages are modified "in place", so you can check the diffs with `git status` and `git diff` before committing and pushing.
+Fetches docs content from other sources (e.g. GitHub repositories) and transforms it to Speechly Docs pages. The page files are modified "in place", so you can check the diffs with `git status` and `git diff` before committing and pushing.
 
 ### Generated pages
 
-- content/client-libraries/react/ui-components
+- `content/client-libraries/react/ui-components`
 
 Requires a Unix-like environment with `bash`, `curl` and `cat` commands.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ If you want to add a subpage, create a new directory under the page directory un
 ## Commiting changes
 
 You can verify everything is working (alt tags correctly placed, no incorrect urls etc) by using (`htmlproofer`)[https://github.com/gjtorikian/html-proofer/blob/master/bin/htmlproofer] Once you are happy with the changes in your local environment, do `git add . && git commit -m 'commit message'` followed by `git push`. 
+
+## Automatic page generation with `./build-docs.sh`
+
+Fetches data from other sources (e.g. GitHub repositories) and modifies the content for Docs. The pages are modified "in place", so you can check the diffs with `git status` and `git diff` before committing and pushing.
+
+### Generated pages
+
+- content/client-libraries/react/ui-components
+
+Requires a Unix-like environment with `bash`, `curl` and `cat` commands.

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,9 +1,15 @@
+CURL_OPTS="--fail --silent --show-error"
+
 # ----------- Build -----------------
 TARGET=_index.md
 TARGET_NAME=_index.md
 TARGET_PATH=content/client-libraries/react/ui-components
+SOURCE=https://raw.githubusercontent.com/speechly/react-ui/main/index.md
 
-echo Building $TARGET_PATH/$TARGET_NAME...
+echo Building \"$TARGET_PATH/$TARGET_NAME\" from \"$SOURCE\"...
 
 cat $TARGET_PATH/$TARGET_NAME.header > $TARGET_PATH/$TARGET_NAME
-curl https://raw.githubusercontent.com/speechly/react-ui/main/index.md >> $TARGET_PATH/$TARGET_NAME
+curl $CURL_OPTS $SOURCE >> $TARGET_PATH/$TARGET_NAME
+
+# ----------- Build -----------------
+echo OK

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -6,4 +6,4 @@ TARGET_PATH=content/client-libraries/react/ui-components
 echo Building $TARGET_PATH/$TARGET_NAME...
 
 cat $TARGET_PATH/$TARGET_NAME.header > $TARGET_PATH/$TARGET_NAME
-curl https://raw.githubusercontent.com/speechly/react-ui/main/docs/react-ui.md >> $TARGET_PATH/$TARGET_NAME
+curl https://raw.githubusercontent.com/speechly/react-ui/main/index.md >> $TARGET_PATH/$TARGET_NAME

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,9 @@
+# ----------- Build -----------------
+TARGET=_index.md
+TARGET_NAME=_index.md
+TARGET_PATH=content/client-libraries/react/ui-components
+
+echo Building $TARGET_PATH/$TARGET_NAME...
+
+cat $TARGET_PATH/$TARGET_NAME.header > $TARGET_PATH/$TARGET_NAME
+curl https://raw.githubusercontent.com/speechly/react-ui/main/docs/react-ui.md >> $TARGET_PATH/$TARGET_NAME

--- a/content/client-libraries/react/ui-components/_index.md
+++ b/content/client-libraries/react/ui-components/_index.md
@@ -61,7 +61,7 @@ Place the components inside your `<SpeechProvider>` block since they depend on t
 ```tsx
 function App() {
   return (
-    <SpeechProvider appId="speechly-app-id" language="en-US">
+    <SpeechProvider appId="014ce3a6-9bbf-4605-976f-087a8f3ec178" language="en-US">
       <BigTranscriptContainer>
         <BigTranscript />
       </BigTranscriptContainer>
@@ -75,13 +75,19 @@ function App() {
 }
 ```
 
-Replace the `speechly-app-id` with the one for your trained speech model from [Speechly Dashboard](https://speechly.com/dashboard).
+To test it, run the app with `npm start`. If you used the default `appId` (Home Automation Demo), hold the push-to-talk button and try saying "Turn off the lights in the kitchen".
+
+If you have already trained your own custom speech model, replace the `appId` with your own acquired from [Speechly Dashboard](https://speechly.com/dashboard).
+
+### Further reading
+
+- [Handling Speech Input in a React App in Speechly Blog](https://www.speechly.com/blog/handling-speech-input-in-a-react-app/)
 
 ## Push-to-Talk Button component
 
 `<PushToTalkButton/>` is a holdable button to control listening for voice input. The icon on the button shows the voice system state.
 
-The Push-to-Talk button is intended to be placed as a floating button at the lower part of the screen using `<PushToTalkButtonContainer/>` so mobile users can react it with ease.
+The Push-to-Talk button is intended to be placed as a floating button at the lower part of the screen using `<PushToTalkButtonContainer/>` so mobile users can reach it with ease.
 
 Desktop users can control it with an optional keyboard hotkey. Our hotkey recommendation is the spacebar.
 
@@ -93,15 +99,15 @@ The placement, size and colors of the button can be customised.
 
 ### States
 
-1. Initial state (Power-on icon): Pressing the button initialises the Speechly API and may trigger the browser microphone permission prompt.
+1. **Offline** (Power-on icon): Pressing the button initialises the Speechly API and may trigger the browser's microphone permission prompt.
 
-2. Ready (Mic icon). Waiting for user to press and hold the button to start listening.
+2. **Ready** (Mic icon). Waiting for user to press and hold the button to start listening.
 
-3. Listening (Highlighted mic). This state is displayed when the component is being held down and Speechly listens for audio input.
+3. **Listening** (Highlighted mic). This state is displayed when the component is being held down and Speechly listens for audio input.
 
-4. Receiving transcript (Pulsating mic). This state may be briefly displayed when the button is released and Speechly finalizes the stream of results.
+4. **Receiving transcript** (Pulsating mic). This state may be briefly displayed when the button is released and Speechly finalizes the stream of results.
 
-5. Error (Broken mic icon). In case of an error (usually during initialisation), the button turns into a broken mic symbol. If you have the optional `<ErrorPanel/>` component in your hierarchy, a description of the problem is displayed. Otherwise, you'll need to look into the browser console to discover the reason for the error.
+5. **Error** (Broken mic icon). In case of an error (usually during initialisation), the button turns into a broken mic symbol. If you have the optional `<ErrorPanel/>` component in your hierarchy, a description of the problem is displayed. Otherwise, you'll need to look into the browser console to discover the reason for the error.
 
 ### Customisation
 

--- a/content/client-libraries/react/ui-components/_index.md.header
+++ b/content/client-libraries/react/ui-components/_index.md.header
@@ -1,0 +1,15 @@
+---
+title: Speechly React UI components
+description: Ready-made UI components for React apps
+display: article
+menu:
+  integrations:
+    title: UI components
+    weight: 2
+    parent: Speechly React client
+---
+
+{{< button "https://github.com/speechly/react-ui" "logo-github" "light" "GitHub" >}}
+
+&nbsp;
+


### PR DESCRIPTION
## Automatic page generation with `./build-docs.sh`

Fetches docs content from other sources (e.g. GitHub repositories) and transforms it to Speechly Docs pages. The page files are modified "in place", so you can check the diffs with `git status` and `git diff` before committing and pushing.

### Generated pages

- content/client-libraries/react/ui-components

Requires a Unix-like environment with `bash`, `curl` and `cat` commands.
