### PR TITLE
Get user avatar from gravatar

### DIFF
--- a/themes/speechly-docs/layouts/partials/components/git-info.html
+++ b/themes/speechly-docs/layouts/partials/components/git-info.html
@@ -1,11 +1,13 @@
 {{ with .GitInfo }}
 {{ $author    := .AuthorName }}
-{{ $authorUrl := printf "https://github.com/%s" $author }}
+{{ $authorHash := md5 .AuthorEmail }}
+{{ $authorUrl := printf "https://www.gravatar.com/avatar/%s" $authorHash }}
 {{ $commit := .Hash }}
 {{ $img       := printf "%s.png" $authorUrl }}
 {{ $commitLink  := printf "https://github.com/speechly/docs/commit/%s" $commit }}
 {{ $issuesLink := printf "https://github.com/speechly/docs/issues/new" }}
 {{ $updated   := dateFormat "January 2, 2006 at 15:04 MST" .AuthorDate }}
+
 <hr>
 <section class="section gitinfo">
   <div class="container">
@@ -14,7 +16,7 @@
     </figure>
 
     <p style="display: inline-block; position: relative; top: -10px; left: 5px" class="is-size-7">
-      {{ T "last_updated_by" }} <a href="https://github.com/{{$author}}">{{ $author }}</a> {{ T "on" }}  <a href="{{$commitLink }}" target="_blank">{{ $updated }}</a>
+      {{ T "last_updated_by" }} {{ $author }} {{ T "on" }}  <a href="{{$commitLink }}" target="_blank">{{ $updated }}</a>
     </p>
     <p class="is-size-7">Found an error on our documentation? Please <a href="https://github.com/speechly/docs/issues/new">file an issue</a> or <a href="https://github.com/speechly/docs/">make a pull request</a></p>
   </div>


### PR DESCRIPTION
`.GitInfo` does not provide us the github user id, so the face image does not work. This change will get the profile image from gravatar using the email address.